### PR TITLE
removed fourier_features.md disclaimer

### DIFF
--- a/papers/fourier_features.md
+++ b/papers/fourier_features.md
@@ -1,7 +1,5 @@
 # Fourier Features Let Networks Learn High Frequency Functions in Low Dimensional Domains
 
-**DISCLAIMER**: Summarized by AI
-
 ## Problem They Are Trying to Solve / Purpose of Method
 
 The paper addresses the **inability of standard coordinate-based MLPs to learn high-frequency functions**


### PR DESCRIPTION
I presented the paper and checked the AI summary. It is spot on and contains all the most important parts of the paper. I think removing the AI disclaimer is fine so that people don't need to second guess the information.